### PR TITLE
Remove decimals from negative numbers

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -379,7 +379,7 @@ export const formattedNum = (number, usd = false, acceptNegatives = false) => {
   }
 
   if (usd) {
-    if (num<0){
+    if (num < 0) {
       return formatDollarAmount(num, 0)
     } else if (num < 0.1) {
       return formatDollarAmount(num, 4)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -379,7 +379,9 @@ export const formattedNum = (number, usd = false, acceptNegatives = false) => {
   }
 
   if (usd) {
-    if (num < 0.1) {
+    if (num<0){
+      return formatDollarAmount(num, 0)
+    } else if (num < 0.1) {
       return formatDollarAmount(num, 4)
     } else {
       return formatDollarAmount(num, 2)


### PR DESCRIPTION
This PR removes decimals from the display of negative values in TradingView charts. This is only a minor change because it is not possible to have negative liquidity/volume but was pointed out that it should still be consistent with the display of positive values.